### PR TITLE
[JS] Support multiple search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Upcoming release
 
-* [#1][1] Fix `associated_class` for unset associations
+* #2 Support multiple search fields on one dashboard
+* #1 Fix `associated_class` for unset associations
 
 ## 0.1.0
 
 Initial release
-
-[1]: https://github.com/fishbrain/administrate-field-belongs_to_search/issues/1

--- a/app/assets/javascripts/belongs_to_search.js
+++ b/app/assets/javascripts/belongs_to_search.js
@@ -1,25 +1,28 @@
 // belongs_to form
 $(function() {
-  $(".field-unit--belongs-to-search select").selectize({
-    valueField: 'id',
-    labelField: 'dashboard_display_name',
-    searchField: 'dashboard_display_name',
-    create: false,
+  $(".field-unit--belongs-to-search select").each(function initializeSelectize(index, element) {
+    var $element = $(element);
+    $element.selectize({
+      valueField: 'id',
+      labelField: 'dashboard_display_name',
+      searchField: 'dashboard_display_name',
+      create: false,
+      searchUrl: $element.data('url') + '?search=',
 
-    load: function(query, callback) {
-      if (!query.length) return callback();
-      this.searchUrl = this.searchUrl || $(".field-unit--belongs-to-search select").data('url');
-      var searchUrl = this.searchUrl + '?search=';
-      $.ajax({
-        url: searchUrl + encodeURIComponent(query),
-        type: 'GET',
-        error: function() {
-          callback();
-        },
-        success: function(res) {
-          callback(res.resources);
-        }
-      });
-    }
+      load: function(query, callback) {
+        if (!query.length) return callback();
+        var searchUrl = this.settings.searchUrl;
+        $.ajax({
+          url: searchUrl + encodeURIComponent(query),
+          type: 'GET',
+          error: function() {
+            callback();
+          },
+          success: function(res) {
+            callback(res.resources);
+          }
+        });
+      },
+    });
   });
 });


### PR DESCRIPTION
This ensures that the `searchUrl` setting is per-field and doesn't fetch
it using the jQuery selector.

Fixes #2