### PR TITLE
Support Administrate 0.6

### DIFF
--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary = 'Plugin that adds search capabilities to belongs_to associations for Administrate'
   gem.license = 'MIT'
 
-  gem.require_paths = %w(lib)
+  gem.require_paths = %w[lib]
   gem.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   gem.test_files = `git ls-files -z -- {spec}/*`.split("\x0")
 

--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   gem.test_files = `git ls-files -z -- {spec}/*`.split("\x0")
 
-  gem.add_dependency 'administrate', '>= 0.3', '< 0.6'
+  gem.add_dependency 'administrate', '>= 0.3', '< 0.7'
   gem.add_dependency 'rails', '>= 4.2', '< 5.1'
   gem.add_dependency 'selectize-rails', '~> 0.6'
 


### PR DESCRIPTION
This loosens the version constraints for Rails and Administrate.