### PR TITLE
Fix a broken instance var from administrate

### DIFF
--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -z -- {spec}/*`.split("\x0")
 
   gem.add_dependency 'administrate', '>= 0.3', '< 1.0'
-  gem.add_dependency 'rails', '>= 4.2', '< 5.2'
+  gem.add_dependency 'rails', '>= 4.2', '< 6.0'
   gem.add_dependency 'selectize-rails', '~> 0.6'
 
   gem.add_development_dependency 'coveralls', '~> 0'

--- a/app/views/administrate/application/index.json.jbuilder
+++ b/app/views/administrate/application/index.json.jbuilder
@@ -19,5 +19,5 @@
 
 json.resources resources do |resource|
   json.id resource.id
-  json.dashboard_display_name @_dashboard.display_resource(resource)
+  json.dashboard_display_name @dashboard.display_resource(resource)
 end


### PR DESCRIPTION
Why:

* Administrate broke the `@_dashboard` var
* Want to use rails 5.2

This change addresses the need by:

* Moving to `@dashboard`
* Bumping dep version