### PR TITLE
Loosen rails version constrain

### DIFF
--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'administrate', '>= 0.3', '< 1.0'
   gem.add_dependency 'jbuilder', '~> 2'
-  gem.add_dependency 'rails', '>= 4.2', '< 7.0'
+  gem.add_dependency 'rails', '>= 4.2', '< 7.1'
   gem.add_dependency 'selectize-rails', '~> 0.6'
 
   gem.add_development_dependency 'coveralls', '~> 0'


### PR DESCRIPTION
I was unable to use in rails 7.0.2.3 but after loosening the version in gemspec I can confirm it is working smooth, would appreciate merge since now in production I link my repo :) Nice timesaver mate keep it up ;) 