### PR TITLE
Allow Rails 7.*

### DIFF
--- a/administrate-field-belongs_to_search.gemspec
+++ b/administrate-field-belongs_to_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'administrate', '>= 0.3', '< 1.0'
   gem.add_dependency 'jbuilder', '~> 2'
-  gem.add_dependency 'rails', '>= 4.2', '< 7.2'
+  gem.add_dependency 'rails', '>= 4.2', '< 8.0'
   gem.add_dependency 'selectize-rails', '~> 0.6'
 
   gem.add_development_dependency 'coveralls', '~> 0'


### PR DESCRIPTION
Rails 7.2 got released - https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released

I was thinking it would be simpler to allow every minor versions of Rails 7 instead of having to bump the dependency file every 6 months :)