### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add it to your Administrate dashboard, for instance:
 ```ruby
 class PostDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    author: Field::BelongsToSearch.with_options(class_name: 'User')
+    author: Field::BelongsToSearch
   }
 # ...
 ```


### PR DESCRIPTION
Because of deprecation warning.

```
DEPRECATION WARNING: The option :class_name is deprecated. Administrate should detect it automatically. Please file an issue at https://github.com/thoughtbot/administrate/issues if you think otherwise. (called from deprecated_option at /usr/local/bundle/gems/administrate-0.20.1/lib/administrate/field/associative.rb:82)
```