### PR TITLE
Use/Match searchable attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/app/assets/javascripts/belongs_to_search.js
+++ b/app/assets/javascripts/belongs_to_search.js
@@ -2,10 +2,11 @@
 $(function() {
   $(".field-unit--belongs-to-search select").each(function initializeSelectize(index, element) {
     var $element = $(element);
+    var searchFields = $element.data('search-fields') && $element.data('search-fields').split(',')
     $element.selectize({
       valueField: 'id',
       labelField: 'dashboard_display_name',
-      searchField: 'dashboard_display_name',
+      searchField: searchFields || 'dashboard_display_name',
       create: false,
       searchUrl: $element.data('url') + '?search=',
 

--- a/app/views/administrate/application/index.json.jbuilder
+++ b/app/views/administrate/application/index.json.jbuilder
@@ -18,6 +18,9 @@
 # [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 
 json.resources resources do |resource|
+  @dashboard.search_attributes.each do |attr|
+    json.set! attr, resource.public_send(attr).to_s
+  end
   json.id resource.id
   json.dashboard_display_name @dashboard.display_resource(resource)
 end

--- a/app/views/fields/belongs_to_search/_form.html.erb
+++ b/app/views/fields/belongs_to_search/_form.html.erb
@@ -21,7 +21,8 @@ that displays all possible records to associate with.
   <%= f.select(field.permitted_attribute,
                nil,
                {},
-               'data-url': polymorphic_url([namespace, field.associated_class], format: :json)) do %>
+               'data-url': polymorphic_url([namespace, field.associated_class], format: :json),
+               'data-search-fields': field.dashboard.search_attributes&.join(",")) do %>
     <%= options_for_select(field.associated_resource_options, field.selected_option) %>
   <% end %>
 </div>

--- a/lib/administrate/field/belongs_to_search.rb
+++ b/lib/administrate/field/belongs_to_search.rb
@@ -22,6 +22,10 @@ module Administrate
       def associated_class
         super
       end
+
+      def dashboard
+        "#{associated_class}Dashboard".constantize.new
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the ability to match the control input with any searchable attribute of the resource. This in effect returns the same records that the user would expect to be returned on the administrate index page, when searching something.
Transparently falls back to pre-existing behavior (matching only the display name of the resource).